### PR TITLE
Fixed issue scrolling after clicking filters btn

### DIFF
--- a/src/container/content/index.js
+++ b/src/container/content/index.js
@@ -23,7 +23,10 @@ const Content = () => {
   const handleYears = (year) => {
     setSelectedYear(year)
     setActiveYear(year)
-    router.push({ pathname: '/', query: { year } })
+    router.push({
+      pathname: "/",
+      query: { ...router.query, year: year },
+    }, undefined, { scroll: false });
   }
 
   /**


### PR DESCRIPTION
fixed issue with scrolling after clicking in years filters.

Related to issue [#](https://github.com/kaf-lamed-beyt/year-in-review/issues/11)